### PR TITLE
Qt6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple to install and use tray icon to control the samplerate and buffersize w
 To run this application, you need the following dependencies:
 
 - Python 3
-- PyQt5
+- PyQt5 or PyQt6 (use -qt6 flag)
 - PipeWire utilities (`pw-metadata` command)
 - Git
 - Wget
@@ -49,14 +49,16 @@ sudo eopkg install python3-qt5 pipewire git wget
 sudo apt-get install python3-pyqt5 pipewire git wget
 ```
 
-## How to Install Piewire Controller
+Note: replace "qt5" with "qt6" if you want to use Qt6
+
+## How to Install Pipewire Controller
 
 Copy the following command, paste it in a terminal and hit [ENTER]. Thats it!
 ```
 wget -qO- https://raw.githubusercontent.com/apapamarkou/pipewire-controller/main/src/pipewire-controller-git-install | bash
 ```
 
-## How to Uninstall Piewire Controller
+## How to Uninstall Pipewire Controller
 
 Copy the following command, paste it in a terminal and hit [ENTER]. Thats it!
 ```

--- a/src/pipewire-controller.py
+++ b/src/pipewire-controller.py
@@ -4,9 +4,23 @@ import os
 import sys
 import json
 import subprocess
-from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QAction, QDialog, QLabel, QVBoxLayout
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt
+
+use_qt6 = '-qt6' in sys.argv
+
+if use_qt6:
+    from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu,  QDialog, QLabel, QVBoxLayout
+    from PyQt6.QtGui import QIcon, QAction
+    from PyQt6.QtCore import Qt
+else:
+    from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QAction, QDialog, QLabel, QVBoxLayout
+    from PyQt5.QtGui import QIcon
+    from PyQt5.QtCore import Qt
+
+try:
+    config_folder = os.path.expanduser("~/.config/pipewire-controller")
+    os.makedirs(config_folder, exist_ok=True)
+except Exception as e:
+    print(f"An error occurred while creating the folder: {e}")
 
 # Configuration file path
 CONFIG_PATH = os.path.expanduser("~/.config/pipewire-controller/pipewire-controller.settings")
@@ -53,12 +67,12 @@ class AboutDialog(QDialog):
         # Create a label with information
         title_label = QLabel("<h1 style='text-align: center;'>PipeWire Controller</h1>"
             "<h2 style='text-align: center;'>Version 1.0</h2>"
-            "<p>A system tray icon to controll pipewire</p>"
+            "<p>A system tray icon to control pipewire</p>"
             "<p>Author <b>Andrianos Papamarkou</b></p>"
             "<p><a href='https://github.com/apapamarkou/pipewire-controller'>Visit on GitHub</a></p>"
             )
 
-        title_label.setAlignment(Qt.AlignCenter)
+        title_label.setAlignment(Qt.AlignmentFlag.AlignCenter) if use_qt6 else title_label.setAlignment(Qt.AlignCenter)
         title_label.setOpenExternalLinks(True)
 
         # Add the labels to the layout
@@ -176,7 +190,7 @@ class TrayIconApp(QApplication):
     def show_about_dialog(self):
         if self.about_dialog is None:
             self.about_dialog = AboutDialog()
-            self.about_dialog.setAttribute(Qt.WA_DeleteOnClose)  # Ensure the dialog is deleted when closed
+            self.about_dialog.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose) if use_qt6 else self.about_dialog.setAttribute(Qt.WA_DeleteOnClose)
         self.about_dialog.show()
         self.about_dialog.raise_()
         self.about_dialog.activateWindow()
@@ -188,4 +202,4 @@ class TrayIconApp(QApplication):
 if __name__ == "__main__":
     check_single_instance()
     app = TrayIconApp(sys.argv)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())


### PR DESCRIPTION
In some systems is preferrable to use Qt6 instead of Qt5 (some users don't even have qt5 installed), this PR adds the ability of use Qt6 with -qt6 argument, giving the possibility to choose between qt5 and qt6